### PR TITLE
asciimap: tweaks, error line numbers and include path

### DIFF
--- a/RossAsciiMap.xml
+++ b/RossAsciiMap.xml
@@ -1,44 +1,4 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
-<!DOCTYPE muclient>
-
-<muclient>
-<plugin
-	 name="RossAsciiMap"
-	 author="Ross Grams"
-	 purpose="ASCII-map miniwindow"
-	 id="4045bd321bb34f7bc51a3ce8"
-	 language="Lua"
-	 save_state="y"
-	 date_written="2019-02-22 13:38:17"
-	 requires="5.05"
-	 version="2.0"
-	 >
-</plugin>
-
-<aliases>
-	<alias
-		match="^asciimap (enable|disable) (.+)$"
-		enabled="y"
-		regexp="y"
-		sequence="100"
-		script="aliasSetGroupsEnabled"
-		>
-	</alias>
-</aliases>
-
-<triggers>
-	<trigger
-		match="^asciimap (enable|disable) (.+)$"
-		enabled="y"
-		regexp="y"
-		sequence="100"
-		script="aliasSetGroupsEnabled"
-		>
-	</trigger>
-</triggers>
-
-<script>
-	<![CDATA[
+<?xml version="1.0" encoding="iso-8859-1"?><!DOCTYPE muclient><muclient><script><![CDATA[ -- this is all on the first line (including this comment) so that lua error messages will have correct line numbers
 
 require "json"
 
@@ -1119,6 +1079,43 @@ function OnPluginDisable()  final() end
 
 	]]>
 </script>
+
+
+<plugin
+	 name="RossAsciiMap"
+	 author="Ross Grams"
+	 purpose="ASCII-map miniwindow"
+	 id="4045bd321bb34f7bc51a3ce8"
+	 language="Lua"
+	 save_state="y"
+	 date_written="2019-02-22 13:38:17"
+	 requires="5.05"
+	 version="2.0"
+	 >
+</plugin>
+
+<aliases>
+	<alias
+		match="^asciimap (enable|disable) (.+)$"
+		enabled="y"
+		regexp="y"
+		sequence="100"
+		script="aliasSetGroupsEnabled"
+		>
+	</alias>
+</aliases>
+
+<triggers>
+	<trigger
+		match="^asciimap (enable|disable) (.+)$"
+		enabled="y"
+		regexp="y"
+		sequence="100"
+		script="aliasSetGroupsEnabled"
+		>
+	</trigger>
+</triggers>
+
 <triggers>
     <trigger
 		script="triggerNPCEntered"

--- a/RossAsciiMap.xml
+++ b/RossAsciiMap.xml
@@ -786,6 +786,7 @@ local pluralizeCache = {
 	man = "men",
 	fisherman = "fishermen",
 	woman = "women",
+	mercenary = "mercenaries",
 	lady = "ladies",
 	sheep = "sheep",
 	grflx = "grflxen",

--- a/RossAsciiMap.xml
+++ b/RossAsciiMap.xml
@@ -789,6 +789,7 @@ local pluralizeCache = {
 	lady = "ladies",
 	sheep = "sheep",
 	grflx = "grflxen",
+	child = "children",
 }
 local singularizeCache = invertKV(pluralizeCache)
 
@@ -1125,7 +1126,7 @@ function OnPluginDisable()  final() end
         enabled="y"
         ignore_case="n"
         keep_evaluating="y"
-        match="^(\*thump\* \*click\* \*thump\* \*click\* )?([aA] |[aA]n |[tT]he )?(?P<npcs>.*) (arrives?|climbs?|enters?|hobbles?|rides?|squeezes?|swims?|trudges?|trundles?|wades?) (.* )?from (the )+(?P<exit>north|northeast|east|southeast|south|southwest|west|northwest)[.]$"
+        match="^(\*thump\* \*click\* \*thump\* \*click\* )?([aA] |[aA]n |[tT]he )?(?P<npcs>.*) (arrives?|climbs?|enters?|hobbles?|rides?|shambles?|shuffles?|squeezes?|swims?|trudges?|trundles?|wades?) (.* )?from (the )+(?P<exit>north|northeast|east|southeast|south|southwest|west|northwest)[.]$"
         regexp="y"
         repeat="n"
         sequence="100"

--- a/RossAsciiMap.xml
+++ b/RossAsciiMap.xml
@@ -46,13 +46,11 @@ local SELF_ID = GetPluginID()
 local GMCP_INTERFACE_ID = "c190b5fc9e83b05d8de996c3"
 local winID = SELF_ID .. "RossAsciiMap"
 
--- Get require path for modules - relative path from mushclient directory.
-local mushClientPath, pluginPath = GetInfo(66), GetPluginInfo(SELF_ID, 20)
-local requirePath = pluginPath:gsub(mushClientPath, ""):gsub("\\", ".")
+local rossPluginsDir = GetPluginInfo(SELF_ID, 20)
 
-local RGBToInt = require (requirePath .. "RGBToInt")
-local window = require (requirePath .. "window")
-local parseMDT = require(requirePath .. "MapDoorTextParser")
+local RGBToInt = dofile(rossPluginsDir .. "RGBToInt.lua")
+local window = dofile(rossPluginsDir .. "window.lua")
+local parseMDT = dofile(rossPluginsDir .. "MapDoorTextParser.lua")
 
 local function copy(t, out)
 	out = out or {}

--- a/window.lua
+++ b/window.lua
@@ -6,8 +6,8 @@
 -- 	* Some wrapping for a window right-click menu.
 -- 		* Lock position and size menu option.
 
-local baseDir = (...):gsub('[^%.]+$', '')
-local RGBToInt = require (baseDir .. "RGBToInt")
+local rossPluginsDir = GetPluginInfo(GetPluginID(), 20);
+local RGBToInt = dofile(rossPluginsDir .. "RGBToInt.lua")
 local max, min = math.max, math.min
 
 local M = {}


### PR DESCRIPTION
I finally upgraded MUSHClient and this time decided to put plugins made by you an me outside the MUSHClient directory, to hopefully make it easier to upgrade next time.

When I did that your black magic with require() couldn't find your lua files, so I put in some different black magic instead. The downside of mine is that if somebody tries to use window.lua from a different plugin it'll look in the directory of their plugin for RGBToInt.lua

Feel free to not merge this. I'm still holding out hope that it's possible for lua to figure out the file path to the file that's currently executing.

Or maybe the least hacky thing is to wrap each lua file in a function like:

```lang=lua
-- window.lua
return function (dir)
    local RGBToInt = doFile(dir .. 'RGBToInt.lua');
    -- ...
    return window
end
```

and pass the directory to it immediately:

```lang=lua
-- plugin.xml
local dir = GetPluginInfo(GetPluginID(), 20);
local window = dofile(dir .. 'window.lua')(dir)
-- ...
```

Annoying boilerplate, but it covers all use cases I can think of. If somebody is using your plugin from another directory then they'll have need to have the path to your plugin directory anyway.


Oy, what a mess. Now I don't feel so bad about putting all my lua in one file.